### PR TITLE
feat(#2562): set default branch to main for semantic release

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,10 @@
     "debug": false,
     "verifyConditions": {
       "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
-    }
+    },
+    "branches": [
+      "main"
+    ]
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.34.0",


### PR DESCRIPTION
## Context

Semantic release fails as it deploys from the default `master` branch, however GitHub default branch is now called `main`

## Objective

This PR sets config to deploy semantic release from `main` branch as semantic still uses default branch as `master`

## References

https://github.com/semantic-release/semantic-release/issues/1581
https://github.blog/2020-07-27-highlights-from-git-2-28/#introducing-init-defaultbranch

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
