### PR TITLE
feat: remove verifyConditions from release

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,6 @@
   },
   "release": {
     "debug": false,
-    "verifyConditions": {
-      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
-    },
     "branches": [
       "main"
     ]


### PR DESCRIPTION
## Context

`verifyConditions` plugin noop is no longer available

## Objective

This PR removes verifyConditions from release property in pacakge.json

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
