### PR TITLE
feat: Add kafka admin api

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,14 +1,14 @@
 kafka:
   # flag for kafka broker
-  enabled: true
+  enabled: KAFKA_ENABLED
   # kafka brokers list
   hosts: KAFKA_BROKERS_LIST
   # sasl options
   sasl:
     # sasl mechanism
-    mechanism: scram-sha-512
+    mechanism: SASL_MECHANISM
     # secret id for sasl/scram
-    secretId: fakesecret
+    secretId: SASL_AWS_SECRET_ID
   # client id of the producer
   clientId: sd-producer
   # Amazon access key

--- a/index.js
+++ b/index.js
@@ -53,34 +53,48 @@ const createMessage = msg => ({
 let producer;
 /**
  * Connects to a Kafka client instance
+ * @param {Boolean} connectAdmin Flag to connect as admin
+ * @param {Object} config The config object
  * @returns Producer promise object
  */
-const connect = async () => {
-    if (!kafkaConfig.enabled) {
+const connect = async (connectAdmin, producerConfig) => {
+    // use config from parameters if available
+    const _config = producerConfig || kafkaConfig;
+
+    if (!_config.enabled) {
         return null;
     }
     if (producer) {
         return producer;
     }
 
-    const secretsStr = await getSecretsValue(kafkaConfig);
+    const secretsStr = await getSecretsValue(_config);
 
     const secrets = JSON.parse(secretsStr);
-    const brokersList = kafkaConfig.hosts.split(',');
+    const brokersList = _config.hosts.split(',');
 
     const kafka = new Kafka({
         logLevel: logLevel.ERROR,
         brokers: brokersList,
-        clientId: kafkaConfig.clientId,
+        clientId: _config.clientId,
         ssl: true,
         sasl: {
-            mechanism: kafkaConfig.sasl.mechanism, // scram-sha-256 or scram-sha-512 or plain
+            mechanism: _config.sasl.mechanism, // scram-sha-256 or scram-sha-512 or plain
             username: secrets.username,
             password: secrets.password
         }
     });
 
     try {
+        if (connectAdmin) {
+            const admin = kafka.admin();
+
+            await admin.connect();
+            logger.info('kafka Broker connected with Admin privileges');
+
+            return admin;
+        }
+
         producer = kafka.producer();
         await producer.connect();
         logger.info('kafka Broker connected');
@@ -111,11 +125,46 @@ const connect = async () => {
 
         return producer;
     } catch (err) {
-        logger.error('kafka broker connection failiure', err);
+        logger.error('kafka broker connection failure', err);
         throw err;
     }
 };
 
+/**
+ * Connects to a Kafka client instance as admin
+ * @returns Admin promise object
+ */
+const connectAdmin = async () => {
+    const admin = connect(true);
+
+    logger.info('kafka Broker Admin connected');
+
+    errorTypes.map(type => {
+        return process.on(type, async () => {
+            try {
+                logger.error(`process.on ${type}`);
+                await admin.disconnect();
+                logger.info('kafka Broker Admin disconnected');
+                process.exit(0);
+            } catch (_) {
+                process.exit(1);
+            }
+        });
+    });
+
+    signalTraps.map(type => {
+        return process.once(type, async () => {
+            try {
+                await admin.disconnect();
+                logger.info('kafka Broker Admin disconnected');
+            } finally {
+                process.kill(process.pid, type);
+            }
+        });
+    });
+
+    return admin;
+};
 /**
  * sends a message to a kafka topic
  * @param {Object} data the data object
@@ -139,7 +188,43 @@ const sendMessage = async (data, topic) => {
     }
 };
 
+/**
+ * gets kafka topic metadata
+ * @param {Object} admin The admin object after calling connect
+ * @param {*} topic      The name of the topic
+ * @returns topic metadata
+ */
+const getTopicMetadata = async (admin, topic) => {
+    const metadata = await admin.fetchTopicMetadata({ topics: [topic] });
+
+    await admin.disconnect();
+
+    return metadata;
+};
+
+/**
+ * creates a kafka topic in the cluster
+ * @param {Object} admin The admin object after calling connect
+ * @param {String} topic The name of the topic to be created
+ */
+const createTopic = async (admin, topic) => {
+    const topics = await admin.listTopics();
+
+    try {
+        if (!topics.includes(topic)) {
+            await admin.createTopics({ topics: [{ topic }] });
+        }
+    } catch (e) {
+        logger.error(`Error creating ${topic} ${e.message}`);
+    }
+
+    await admin.disconnect();
+};
+
 module.exports = {
     connect,
-    sendMessage
+    connectAdmin,
+    sendMessage,
+    createTopic,
+    getTopicMetadata
 };

--- a/index.js
+++ b/index.js
@@ -148,12 +148,10 @@ const connect = async () => {
  * @param {Object} data the data object
  * @param {String} topic the topic name
  */
-const sendMessage = async (producer, data, topic) => {
-    const { job, buildConfig } = data;
+const sendMessage = async (producer, data, topic, messageId) => {
     // after the produce has connected, we start start sending messages
-
     try {
-        logger.info(`publishing msg ${job}:${buildConfig.buildId} to kafka topic:${topic}`);
+        logger.info(`publishing msg ${messageId} to kafka topic:${topic}`);
         await producer.connect();
         await producer.send({
             topic,
@@ -161,11 +159,9 @@ const sendMessage = async (producer, data, topic) => {
             acks: 1,
             messages: [createMessage(data)]
         });
-        logger.info(`successfully published msg id ${job}:${buildConfig.buildId} -> topic ${topic}`);
+        logger.info(`successfully published message ${messageId} -> topic ${topic}`);
     } catch (e) {
-        logger.error(
-            `Publishing message ${buildConfig.buildId} to topic ${topic} failed ${e.message}: stack: ${e.stack}`
-        );
+        logger.error(`publishing message ${messageId} to topic ${topic} failed ${e.message}: stack: ${e.stack}`);
     }
 };
 

--- a/index.js
+++ b/index.js
@@ -88,9 +88,6 @@ const connect = async () => {
 
     try {
         const producer = kafka.producer();
-
-        await producer.connect();
-
         const { DISCONNECT, CONNECT } = producer.events;
 
         producer.on(CONNECT, e => logger.info(`kafka Broker connected ${e.timestamp}: ${e}`));
@@ -119,6 +116,8 @@ const connect = async () => {
                 }
             });
         });
+
+        await producer.connect();
 
         return producer;
     } catch (err) {
@@ -163,9 +162,6 @@ const connectAdmin = async () => {
     const kafka = await getKafkaObject();
 
     const admin = kafka.admin();
-
-    await admin.connect();
-
     const { DISCONNECT, CONNECT } = admin.events;
 
     admin.on(CONNECT, e => logger.info(`kafka Admin connected ${e.timestamp}: ${e}`));
@@ -194,6 +190,8 @@ const connectAdmin = async () => {
             }
         });
     });
+
+    await admin.connect();
 
     return admin;
 };

--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ const connect = async () => {
         producer.on(CONNECT, e => logger.info(`kafka Broker connected ${e.timestamp}: ${e}`));
         producer.on(DISCONNECT, e => logger.info(`kafka Broker disconnected ${e.timestamp}: ${e}`));
 
-        errorTypes.map(type => {
+        errorTypes.forEach(type => {
             return process.on(type, async () => {
                 try {
                     logger.error(`process.on ${type}`);
@@ -109,7 +109,7 @@ const connect = async () => {
             });
         });
 
-        signalTraps.map(type => {
+        signalTraps.forEach(type => {
             return process.once(type, async () => {
                 try {
                     await producer.disconnect();
@@ -171,7 +171,7 @@ const connectAdmin = async () => {
     admin.on(CONNECT, e => logger.info(`kafka Admin connected ${e.timestamp}: ${e}`));
     admin.on(DISCONNECT, e => logger.info(`kafka Admin disconnected ${e.timestamp}: ${e}`));
 
-    errorTypes.map(type => {
+    errorTypes.forEach(type => {
         return process.on(type, async () => {
             try {
                 logger.error(`process.on ${type}`);
@@ -184,7 +184,7 @@ const connectAdmin = async () => {
         });
     });
 
-    signalTraps.map(type => {
+    signalTraps.forEach(type => {
         return process.once(type, async () => {
             try {
                 await admin.disconnect();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -122,7 +122,7 @@ describe('index', () => {
             const producer = await index.connect();
             const msg = { buildConfig: { buildId: 123 }, job: 'start' };
 
-            await index.sendMessage(producer, msg, topicName);
+            await index.sendMessage(producer, msg, topicName, 'msg1');
 
             assert.calledTwice(producer.connect);
             assert.calledOnce(producer.send);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -143,6 +143,7 @@ describe('index', () => {
             await index.createTopic(admin, topicName);
 
             assert.calledOnce(admin.connect);
+            assert.calledOnce(admin.listTopics);
             assert.calledOnce(admin.createTopics);
             assert.calledOnce(admin.disconnect);
         });


### PR DESCRIPTION
## Context

PRoducer Service needs admin API to create topic and fetch topic information

## Objective

This PR adds mechanism to connect as admin and adds new admin APIs to the service

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
